### PR TITLE
Null issue when calling .ToString() method

### DIFF
--- a/src/jQueryDatatableServerSideNetCore22/Extensions/LinqExtensions.cs
+++ b/src/jQueryDatatableServerSideNetCore22/Extensions/LinqExtensions.cs
@@ -40,7 +40,7 @@ namespace jQueryDatatableServerSideNetCore22.Extensions
 
                 //Expression
                 sourceList = sourceList.Where(c =>
-                    properties.Any(p => p.GetValue(c).ToString()
+                    properties.Any(p => p.GetValue(c) != null && p.GetValue(c).ToString()
                         .Contains(query, StringComparison.InvariantCultureIgnoreCase)));
             }
             catch (Exception e)


### PR DESCRIPTION
To prevent getting *"object reference not set to an instance of an object"* error when value of some properties in DbEntity are **null** or **empty string**.

Hope this will help!